### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ bower install hybicon
 or CDN by [jsDelivr][jsdelivr]
 
 ```html
-<script type="text/javascript" src="https://cdn.jsdelivr.net/hybicon/1.4.0/hybicon.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/hybicon@1.4.0/js/hybicon.min.js"></script>
 ```
 
 ## Author


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/hybicon.

Feel free to ping me if you have any questions regarding this change.